### PR TITLE
Highlight quick import input text on focus

### DIFF
--- a/extension/src/overlay/QuickImportPopup.tsx
+++ b/extension/src/overlay/QuickImportPopup.tsx
@@ -397,7 +397,8 @@ export const QuickImportPopup: React.FC<QuickImportPopupProps> = ({
                 setShowDeckDropdown(true);
                 setDeckSelectedIndex(-1);
               }}
-              onFocus={() => {
+              onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
+                event.target.select();
                 if (decks.length > 0) {
                   setShowDeckDropdown(true);
                   setDeckSelectedIndex(-1);
@@ -562,7 +563,8 @@ export const QuickImportPopup: React.FC<QuickImportPopupProps> = ({
                 setShowModelDropdown(true);
                 setModelSelectedIndex(-1);
               }}
-              onFocus={() => {
+              onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
+                event.target.select();
                 if (models.length > 0) {
                   setShowModelDropdown(true);
                   setModelSelectedIndex(-1);


### PR DESCRIPTION
## Summary
- select the existing text in the quick import deck and model inputs when they gain focus so the dropdown search updates immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e6647d7378832e88aa19c6297ac2fc