### PR TITLE
Highlight quick import inputs on focus

### DIFF
--- a/extension/src/overlay/QuickImportPopup.tsx
+++ b/extension/src/overlay/QuickImportPopup.tsx
@@ -397,7 +397,8 @@ export const QuickImportPopup: React.FC<QuickImportPopupProps> = ({
                 setShowDeckDropdown(true);
                 setDeckSelectedIndex(-1);
               }}
-              onFocus={() => {
+              onFocus={(event) => {
+                event.target.select();
                 if (decks.length > 0) {
                   setShowDeckDropdown(true);
                   setDeckSelectedIndex(-1);
@@ -562,7 +563,8 @@ export const QuickImportPopup: React.FC<QuickImportPopupProps> = ({
                 setShowModelDropdown(true);
                 setModelSelectedIndex(-1);
               }}
-              onFocus={() => {
+              onFocus={(event) => {
+                event.target.select();
                 if (models.length > 0) {
                   setShowModelDropdown(true);
                   setModelSelectedIndex(-1);


### PR DESCRIPTION
## Summary
- select the existing deck text when the quick import deck field gains focus
- do the same for the quick import model field so typing replaces the previous value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e6627e18f4832ebbcfc75d6a30efc9