### PR TITLE
Refresh recent choices immediately after saving

### DIFF
--- a/extension/src/overlay/QuickImportPopup.tsx
+++ b/extension/src/overlay/QuickImportPopup.tsx
@@ -214,8 +214,8 @@ export const QuickImportPopup: React.FC<QuickImportPopupProps> = ({
   });
 
   // Get recent items
-  const recentDecks = useMemo(() => getRecentDecks(), []);
-  const recentModels = useMemo(() => getRecentModels(), []);
+  const [recentDecks, setRecentDecks] = useState<string[]>(() => getRecentDecks());
+  const [recentModels, setRecentModels] = useState<string[]>(() => getRecentModels());
 
   // Filter decks with smart search
   const filteredDecks = useMemo(() => {
@@ -274,6 +274,7 @@ export const QuickImportPopup: React.FC<QuickImportPopupProps> = ({
     if (deck) {
       applyDeck(deck);
       saveRecentDeck(deck);
+      setRecentDecks(getRecentDecks());
     }
   }, [deck, applyDeck]);
 
@@ -281,6 +282,7 @@ export const QuickImportPopup: React.FC<QuickImportPopupProps> = ({
     if (model) {
       applyModel(model);
       saveRecentModel(model);
+      setRecentModels(getRecentModels());
     }
   }, [model, applyModel]);
 
@@ -397,7 +399,8 @@ export const QuickImportPopup: React.FC<QuickImportPopupProps> = ({
                 setShowDeckDropdown(true);
                 setDeckSelectedIndex(-1);
               }}
-              onFocus={() => {
+              onFocus={(event) => {
+                event.target.select();
                 if (decks.length > 0) {
                   setShowDeckDropdown(true);
                   setDeckSelectedIndex(-1);
@@ -562,7 +565,8 @@ export const QuickImportPopup: React.FC<QuickImportPopupProps> = ({
                 setShowModelDropdown(true);
                 setModelSelectedIndex(-1);
               }}
-              onFocus={() => {
+              onFocus={(event) => {
+                event.target.select();
                 if (models.length > 0) {
                   setShowModelDropdown(true);
                   setModelSelectedIndex(-1);

--- a/extension/src/overlay/components/DeckControls.tsx
+++ b/extension/src/overlay/components/DeckControls.tsx
@@ -116,10 +116,15 @@ export const DeckControls: React.FC = () => {
     setTags(defaults.tags);
   }, [defaults.deck, defaults.model, defaults.tags]);
 
+  // Get recent choices
+  const [recentDecks, setRecentDecks] = useState<string[]>(() => getRecentDecks());
+  const [recentModels, setRecentModels] = useState<string[]>(() => getRecentModels());
+
   useEffect(() => {
     if (deck) {
       applyDeck(deck);
       saveRecentDeck(deck); // Save to recent
+      setRecentDecks(getRecentDecks());
     }
   }, [deck, applyDeck]);
 
@@ -127,6 +132,7 @@ export const DeckControls: React.FC = () => {
     if (model) {
       applyModel(model);
       saveRecentModel(model); // Save to recent
+      setRecentModels(getRecentModels());
     }
   }, [model, applyModel]);
 
@@ -145,10 +151,6 @@ export const DeckControls: React.FC = () => {
   const [showCustomModel, setShowCustomModel] = useState(false);
   const [deckSearchQuery, setDeckSearchQuery] = useState('');
   const [modelSearchQuery, setModelSearchQuery] = useState('');
-  
-  // Get recent choices
-  const recentDecks = useMemo(() => getRecentDecks(), []);
-  const recentModels = useMemo(() => getRecentModels(), []);
 
   // Sort decks: selected on top, then recent, then alphabetically
   const sortedDecks = useMemo(() => {


### PR DESCRIPTION
## Summary
- keep the quick-import deck/model recent lists in sync after saving a new selection
- update the deck controls recents so newly chosen decks/models appear without reloading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e6627e18f4832ebbcfc75d6a30efc9