### PR TITLE
Refine options UI with live summary panel

### DIFF
--- a/extension/src/options/App.tsx
+++ b/extension/src/options/App.tsx
@@ -1,15 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { UserPreferences } from '@messaging/schemas';
 import { loadPreferences, persistPreferences } from '@shared/preferences';
 import { PreferencesForm } from './components/PreferencesForm';
+import { SummaryPanel } from './components/SummaryPanel';
 
 export const App: React.FC = () => {
   const [preferences, setPreferences] = useState<UserPreferences | null>(null);
+  const [draft, setDraft] = useState<UserPreferences | null>(null);
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<string>('');
 
   useEffect(() => {
-    void loadPreferences().then((prefs) => setPreferences(prefs));
+    void loadPreferences().then((prefs) => {
+      setPreferences(prefs);
+      setDraft(prefs);
+    });
   }, []);
 
   const handleSave = async (next: UserPreferences) => {
@@ -17,6 +22,7 @@ export const App: React.FC = () => {
     try {
       await persistPreferences(next);
       setPreferences(next);
+      setDraft(next);
       setStatus('Preferences saved');
       setTimeout(() => setStatus(''), 1500);
     } catch (error) {
@@ -26,9 +32,22 @@ export const App: React.FC = () => {
     }
   };
 
-  if (!preferences) {
+  const handleReset = () => {
+    if (preferences) {
+      setDraft(preferences);
+    }
+  };
+
+  const hasChanges = useMemo(() => {
+    if (!preferences || !draft) {
+      return false;
+    }
+    return JSON.stringify(preferences) !== JSON.stringify(draft);
+  }, [preferences, draft]);
+
+  if (!draft) {
     return (
-      <main style={baseStyle}>
+      <main style={pageStyle}>
         <h1 style={{ marginBottom: '1rem' }}>Anki Assistant Preferences</h1>
         <p style={{ color: '#64748b' }}>Loading…</p>
       </main>
@@ -36,22 +55,84 @@ export const App: React.FC = () => {
   }
 
   return (
-    <main style={baseStyle}>
-      <header style={{ marginBottom: '1.5rem' }}>
-        <h1 style={{ marginBottom: '0.25rem' }}>Anki Assistant Preferences</h1>
-        <p style={{ color: '#64748b' }}>
-          Configure default decks, detection heuristics, and media policies for new captures.
-        </p>
+    <main style={pageStyle}>
+      <header style={headerStyle}>
+        <div>
+          <p style={eyebrowStyle}>Workspace Controls</p>
+          <h1 style={{ margin: 0 }}>Anki Assistant Preferences</h1>
+          <p style={subtitleStyle}>
+            Tune how captures are organised, interpreted, and stored. Changes are saved locally and
+            synced to future sessions once you hit save.
+          </p>
+        </div>
       </header>
-      <PreferencesForm preferences={preferences} onSave={handleSave} saving={saving} />
-      {status && <p style={{ marginTop: '1rem', color: '#0f766e' }}>{status}</p>}
+      <div style={contentLayout}>
+        <section style={formColumn}>
+          <PreferencesForm
+            draft={draft}
+            onChange={setDraft}
+            onSave={handleSave}
+            onReset={handleReset}
+            saving={saving}
+            hasChanges={hasChanges}
+          />
+        </section>
+        <aside style={summaryColumn}>
+          <SummaryPanel draft={draft} status={status} saving={saving} />
+        </aside>
+      </div>
     </main>
   );
 };
 
-const baseStyle: React.CSSProperties = {
+const pageStyle: React.CSSProperties = {
   margin: '0 auto',
-  maxWidth: '960px',
-  padding: '2rem',
-  fontFamily: 'Inter, system-ui, sans-serif'
+  maxWidth: '1080px',
+  padding: '2.5rem',
+  fontFamily: 'Inter, system-ui, sans-serif',
+  color: '#0f172a'
+};
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-end',
+  marginBottom: '2rem'
+};
+
+const eyebrowStyle: React.CSSProperties = {
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  fontSize: '0.75rem',
+  color: '#6366f1',
+  marginBottom: '0.35rem'
+};
+
+const subtitleStyle: React.CSSProperties = {
+  color: '#64748b',
+  maxWidth: '58ch',
+  marginTop: '0.75rem',
+  lineHeight: 1.6
+};
+
+const contentLayout: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '2rem'
+};
+
+const formColumn: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  flex: '1 1 520px',
+  minWidth: '280px'
+};
+
+const summaryColumn: React.CSSProperties = {
+  position: 'sticky',
+  top: '2.5rem',
+  alignSelf: 'flex-start',
+  flex: '0 0 320px',
+  minWidth: '260px'
 };

--- a/extension/src/options/components/PreferencesForm.tsx
+++ b/extension/src/options/components/PreferencesForm.tsx
@@ -1,15 +1,18 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import type { UserPreferences } from '@messaging/schemas';
 import { SiteRules } from './SiteRules';
 
 interface Props {
-  preferences: UserPreferences;
+  draft: UserPreferences;
   saving: boolean;
+  hasChanges: boolean;
+  onChange: React.Dispatch<React.SetStateAction<UserPreferences>>;
   onSave: (preferences: UserPreferences) => void;
+  onReset: () => void;
 }
 
-export const PreferencesForm: React.FC<Props> = ({ preferences, onSave, saving }) => {
-  const [draft, setDraft] = useState<UserPreferences>({ ...preferences });
+export const PreferencesForm: React.FC<Props> = ({ draft, onChange, onSave, saving, hasChanges, onReset }) => {
+  const setDraft = onChange;
 
   const tagPreview = useMemo(() => {
     const now = new Date();
@@ -46,9 +49,12 @@ export const PreferencesForm: React.FC<Props> = ({ preferences, onSave, saving }
   };
 
   return (
-    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+    <form onSubmit={handleSubmit} style={formStyle}>
       <section style={sectionStyle}>
-        <h2 style={sectionTitle}>General</h2>
+        <header style={sectionHeader}>
+          <h2 style={sectionTitle}>General</h2>
+          <p style={sectionDescription}>Where newly captured cards should live and how they are tagged.</p>
+        </header>
         <div style={fieldGrid}>
           <label style={labelStyle}>
             <span>Default Deck</span>
@@ -80,7 +86,10 @@ export const PreferencesForm: React.FC<Props> = ({ preferences, onSave, saving }
       </section>
 
       <section style={sectionStyle}>
-        <h2 style={sectionTitle}>Detection Heuristics</h2>
+        <header style={sectionHeader}>
+          <h2 style={sectionTitle}>Detection Heuristics</h2>
+          <p style={sectionDescription}>Toggle the strategies used to infer question and answer boundaries.</p>
+        </header>
         <div style={toggleGrid}>
           {(
             [
@@ -103,7 +112,10 @@ export const PreferencesForm: React.FC<Props> = ({ preferences, onSave, saving }
       </section>
 
       <section style={sectionStyle}>
-        <h2 style={sectionTitle}>Media Policy</h2>
+        <header style={sectionHeader}>
+          <h2 style={sectionTitle}>Media Policy</h2>
+          <p style={sectionDescription}>Control how linked assets are downloaded and transformed.</p>
+        </header>
         <div style={fieldGrid}>
           <label style={labelStyle}>
             <span>Download External</span>
@@ -157,7 +169,12 @@ export const PreferencesForm: React.FC<Props> = ({ preferences, onSave, saving }
       </section>
 
       <section style={sectionStyle}>
-        <h2 style={sectionTitle}>Site Rules</h2>
+        <header style={sectionHeader}>
+          <h2 style={sectionTitle}>Site Rules</h2>
+          <p style={sectionDescription}>
+            Maintain allow and block lists to override heuristics on specific domains.
+          </p>
+        </header>
         <SiteRules
           allowlist={draft.siteAllowlist}
           blocklist={draft.siteBlocklist}
@@ -168,7 +185,10 @@ export const PreferencesForm: React.FC<Props> = ({ preferences, onSave, saving }
       </section>
 
       <section style={sectionStyle}>
-        <h2 style={sectionTitle}>Accessibility</h2>
+        <header style={sectionHeader}>
+          <h2 style={sectionTitle}>Accessibility</h2>
+          <p style={sectionDescription}>Shortcuts and fallbacks that help you capture content quickly.</p>
+        </header>
         <label style={toggleStyle}>
           <input
             type="checkbox"
@@ -187,13 +207,22 @@ export const PreferencesForm: React.FC<Props> = ({ preferences, onSave, saving }
         </label>
       </section>
 
-      <footer style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.75rem' }}>
-        <button type="submit" disabled={saving} style={submitStyle}>
+      <footer style={footerStyle}>
+        <button type="button" disabled={!hasChanges || saving} style={secondaryButtonStyle} onClick={onReset}>
+          Reset changes
+        </button>
+        <button type="submit" disabled={saving || !hasChanges} style={submitStyle}>
           {saving ? 'Saving…' : 'Save Preferences'}
         </button>
       </footer>
     </form>
   );
+};
+
+const formStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem'
 };
 
 const sectionStyle: React.CSSProperties = {
@@ -204,10 +233,21 @@ const sectionStyle: React.CSSProperties = {
   border: '1px solid #e2e8f0'
 };
 
+const sectionHeader: React.CSSProperties = {
+  marginBottom: '1.1rem'
+};
+
 const sectionTitle: React.CSSProperties = {
   marginTop: 0,
   marginBottom: '1rem',
   fontSize: '1.15rem'
+};
+
+const sectionDescription: React.CSSProperties = {
+  margin: 0,
+  color: '#64748b',
+  fontSize: '0.85rem',
+  lineHeight: 1.5
 };
 
 const fieldGrid: React.CSSProperties = {
@@ -259,4 +299,20 @@ const submitStyle: React.CSSProperties = {
   border: 'none',
   cursor: 'pointer',
   fontSize: '0.95rem'
+};
+
+const secondaryButtonStyle: React.CSSProperties = {
+  padding: '0.6rem 1.1rem',
+  borderRadius: '0.65rem',
+  background: '#e2e8f0',
+  color: '#1e293b',
+  border: 'none',
+  cursor: 'pointer',
+  fontSize: '0.9rem'
+};
+
+const footerStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '0.75rem'
 };

--- a/extension/src/options/components/SummaryPanel.tsx
+++ b/extension/src/options/components/SummaryPanel.tsx
@@ -1,0 +1,149 @@
+import React, { useMemo } from 'react';
+import type { UserPreferences } from '@messaging/schemas';
+
+type Props = {
+  draft: UserPreferences;
+  status: string;
+  saving: boolean;
+};
+
+export const SummaryPanel: React.FC<Props> = ({ draft, status, saving }) => {
+  const tagPreview = useMemo(() => {
+    const now = new Date();
+    return draft.tagTemplate
+      .replace('{domain}', draft.siteAllowlist[0] ?? 'example.com')
+      .replace('{title}', 'Captured page title')
+      .replace('{YYYY-MM-DD}', now.toISOString().split('T')[0])
+      .replace('{HH:mm}', now.toTimeString().slice(0, 5));
+  }, [draft.tagTemplate, draft.siteAllowlist]);
+
+  const activeHeuristics = useMemo(
+    () =>
+      Object.entries(draft.heuristics)
+        .filter(([, enabled]) => enabled)
+        .map(([key]) => heuristicCopy[key as keyof typeof draft.heuristics]),
+    [draft.heuristics]
+  );
+
+  const mediaSummary = `${draft.mediaPolicy.downloadExternal ? 'Download external' : 'Skip external'} • ${
+    draft.mediaPolicy.convertWebP ? 'Convert to WebP' : 'Keep original format'
+  }`;
+
+  return (
+    <div style={panelStyle}>
+      <header>
+        <h2 style={panelTitle}>Live summary</h2>
+        <p style={panelDescription}>
+          A quick overview of how your next capture will behave based on the settings on the left.
+        </p>
+      </header>
+
+      <div style={cardStyle}>
+        <p style={cardEyebrow}>Destination</p>
+        <h3 style={cardHeading}>{draft.defaultDeck ?? 'Deck not specified'}</h3>
+        <p style={cardBody}>Model: {draft.defaultModel}</p>
+        <p style={cardBody}>Tags: {tagPreview}</p>
+      </div>
+
+      <div style={cardStyle}>
+        <p style={cardEyebrow}>Heuristics</p>
+        {activeHeuristics.length > 0 ? (
+          <ul style={listStyle}>
+            {activeHeuristics.map((label) => (
+              <li key={label}>{label}</li>
+            ))}
+          </ul>
+        ) : (
+          <p style={cardBody}>No automatic detection enabled — captures will use manual selection only.</p>
+        )}
+      </div>
+
+      <div style={cardStyle}>
+        <p style={cardEyebrow}>Media policy</p>
+        <p style={cardBody}>{mediaSummary}</p>
+        <p style={cardSubtle}>
+          Concurrency: {draft.mediaPolicy.concurrency} • Retry: {draft.mediaPolicy.retryLimit} • Max size:{' '}
+          {draft.mediaPolicy.maxSizeMB}MB
+        </p>
+      </div>
+
+      <div style={cardStyle}>
+        <p style={cardEyebrow}>Site rules</p>
+        <p style={cardBody}>Allow: {draft.siteAllowlist.length || 'None'} • Block: {draft.siteBlocklist.length || 'None'}</p>
+      </div>
+
+      <div style={{ ...cardStyle, background: '#f0fdf4', borderColor: '#bbf7d0' }}>
+        <p style={{ ...cardEyebrow, color: '#047857' }}>Status</p>
+        <p style={{ ...cardBody, color: '#047857' }}>{saving ? 'Saving…' : status || 'Ready to save changes'}</p>
+      </div>
+    </div>
+  );
+};
+
+const panelStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.25rem'
+};
+
+const panelTitle: React.CSSProperties = {
+  margin: 0,
+  fontSize: '1.25rem'
+};
+
+const panelDescription: React.CSSProperties = {
+  marginTop: '0.5rem',
+  color: '#64748b',
+  lineHeight: 1.5,
+  fontSize: '0.9rem'
+};
+
+const cardStyle: React.CSSProperties = {
+  background: '#ffffff',
+  border: '1px solid #e2e8f0',
+  borderRadius: '0.75rem',
+  padding: '1rem',
+  boxShadow: '0 8px 24px rgba(15, 23, 42, 0.06)'
+};
+
+const cardEyebrow: React.CSSProperties = {
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  fontSize: '0.7rem',
+  color: '#6366f1',
+  marginBottom: '0.5rem'
+};
+
+const cardHeading: React.CSSProperties = {
+  margin: 0,
+  fontSize: '1rem',
+  color: '#0f172a'
+};
+
+const cardBody: React.CSSProperties = {
+  margin: '0.4rem 0',
+  color: '#1e293b',
+  fontSize: '0.9rem'
+};
+
+const cardSubtle: React.CSSProperties = {
+  margin: 0,
+  color: '#64748b',
+  fontSize: '0.8rem'
+};
+
+const listStyle: React.CSSProperties = {
+  margin: 0,
+  paddingLeft: '1.2rem',
+  color: '#1e293b',
+  fontSize: '0.9rem',
+  display: 'grid',
+  gap: '0.35rem'
+};
+
+const heuristicCopy: Record<keyof UserPreferences['heuristics'], string> = {
+  explicitMarkers: 'Explicit markers (Q:, A:)',
+  structureHints: 'Structure hints (headings + paragraph)',
+  questionMarks: 'Question mark inference',
+  listTable: 'List/table pairing'
+};


### PR DESCRIPTION
## Summary
- restructure the options page with a refreshed header and shared draft state between the form and layout
- enhance the preferences form with descriptive section headers, change detection, and a reset affordance
- add a live summary panel that previews capture destinations, heuristics, media policy, and status feedback

## Testing
- pnpm lint *(fails: existing lint violations in unrelated background/overlay files)*

------
https://chatgpt.com/codex/tasks/task_b_68e71fb5cb64832e9d99bfe533da35c4